### PR TITLE
fix for pages with no date value

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,6 +1,8 @@
 {{ define "main" }}
 <h1 class="post-title">{{ .Title }}</h1>
+    {{ if .Date }}
     <time>{{ .Date.Format "January 2, 2006" }}</time>
+    {{ end }}
     <div>
         <p>
         {{ .Content }}


### PR DESCRIPTION
About pages and similar might not have a meaningful date value, so avoid formatting the value if not present, since that would output a nonsensical value like “January 1, 0001”.

Thanks for creating this theme :)