### PR TITLE
Fixes multi-language support in header

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -36,7 +36,7 @@
         <p>Page {{ $paginator.PageNumber}} of {{ $paginator.TotalPages }}</p>
         <div class="paginator-group">
             {{ if $paginator.HasPrev }}
-            <a class="color-link" href="{{ $paginator.Prev.URL }}">
+            <a class="color-link" href="{{ $paginator.Prev.URL | relLangURL }}">
                     <svg width="13px" height="9px" viewBox="0 0 13 9" version="1.1" xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink">
                         <g class="color-arrow" fill="#63BDA2" fill-rule="nonzero">
                             <polygon id="Path" points="1.75929935 4.50000282 5.3292523 7.62371165 4.6707477 8.37628835 0.240700645 4.49999718 4.67081049 0.623709205 5.32930951 1.37629079"></polygon>
@@ -47,7 +47,7 @@
             </a>
             {{ end }}
             {{ if $paginator.HasNext }}
-                <a class="color-link older" href="{{ $paginator.Next.URL }}">
+                <a class="color-link older" href="{{ $paginator.Next.URL | relLangURL }}">
                     Older
                     <svg width="13px" height="9px" viewBox="0 0 13 9" version="1.1" xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink">
                             <g class="color-arrow" fill="#63BDA2" fill-rule="nonzero">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,5 @@
 <header>
     <div class="site-title">
-        <a href="{{ "/" | relURL }}">{{ .Site.Title }}</a>
+        <a href="{{ "/" | relLangURL }}">{{ .Site.Title }}</a>
     </div>  
 </header>

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -3,7 +3,7 @@
   {{ partial "header.html" . }}
   <div class="nav-menu">
   {{ range .Site.Menus.main }}
-    <a class="color-link nav-link" href="{{ .URL }}">{{ .Name }}</a>
+    <a class="color-link nav-link" href="{{ .URL | relLangURL }}">{{ .Name }}</a>
   {{ end }}
   <a class="color-link nav-link" href="{{ .Site.RSSLink }}" target="_blank" rel="noopener" type="application/rss+xml">RSS</a>
 </div>


### PR DESCRIPTION
For https://github.com/kimcc/hugo-theme-noteworthy/issues/18. This fixes the header in multi-lang mode.