### PR TITLE
Fix footnote SCSS not being compatible with generated markup

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -339,16 +339,14 @@ nav {
     height: auto;
 }
 
-.footnote-ref {
-    a {
-        margin-left: 0.3em;
-    }
+a.footnote-ref {
+    margin-left: 0.3em;
 
-    a::before {
+    &::before {
         content: "[";
     }
 
-    a::after {
+    &::after {
         content: "]";
     }
 }


### PR DESCRIPTION
Markdown: `some text[^1] and some more`
Resulting markup: `<p>some text<sup id="fnref:1"><a href="#fn:1" class="footnote-ref" role="doc-noteref">1</a></sup> and some more</p>`

The style file assumed the `footnote-ref` class to appear for the `<sup>` tag, which was incorrect.