### PR TITLE
fix issue #38 by using relLangURL to generate href's

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -26,7 +26,7 @@
         {{if .Params.tags}}
         <hr class="footer-divider">
         {{ range .Params.tags }}
-            <a class="tag" href="/tags/{{ . | urlize }}">#{{.}}</a>
+	    <a class="tag" href="{{ "/tags/" | relLangURL }}{{ . | urlize }}">#{{.}}</a>
         {{ end }}
       {{ end }}
     </div>


### PR DESCRIPTION
One line change as described in issue #38 

Tested with `hugo server`.

### To test:

1.  Clone https://github.com/ranger6/noteworthy-example and checkout the `issue38` branch.  This branch points to the issue38 branch of the noteworthy theme submodule: https://github.com/ranger6/hugo-theme-noteworthy
2. Initialize the submodule
3. Run `hugo server` or generate the site and publish

N.B. the baseURL in this example points to a GitHub pages site: https://ranger6.github.io/noteworthy-example/ This site currently contains the example *with the bug present* (e.g. published from the master branches, not the fix branch).