### PR TITLE
Replace outdated RSSLink template variable

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -5,7 +5,7 @@
   {{ range .Site.Menus.main }}
     <a class="color-link nav-link" href="{{ .URL }}">{{ .Name }}</a>
   {{ end }}
-  <a class="color-link nav-link" href="{{ .Site.RSSLink }}" target="_blank" rel="noopener" type="application/rss+xml">RSS</a>
+  <a class="color-link nav-link" href="{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}" target="_blank" rel="noopener" type="application/rss+xml">RSS</a>
 </div>
 {{ partial "footer.html" . }}
 </nav>


### PR DESCRIPTION
This pull request replaces the outdated `.Site.RSSLink` variable with `{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}`