### PR TITLE
Use hugo.IsServer instead of deprecated .Site.IsServer

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -29,7 +29,7 @@
     {{ with .OutputFormats.Get "RSS" }}
     {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
     {{ end }}
-    {{- if not .Site.IsServer -}}
+    {{- if not hugo.IsServer -}}
       {{ template "_internal/google_analytics.html" . }}
     {{- end -}}
 </head>

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -5,7 +5,9 @@
   {{ range .Site.Menus.main }}
     <a class="color-link nav-link" href="{{ .URL }}">{{ .Name }}</a>
   {{ end }}
-  <a class="color-link nav-link" href="{{ .Site.RSSLink }}" target="_blank" rel="noopener" type="application/rss+xml">RSS</a>
+  {{ with .OutputFormats.Get "rss" -}}
+    {{ printf `<a class="color-link nav-link" href=%q target="_blank" rel="noopener" type=%q>RSS</a>` .Permalink .MediaType.Type | safeHTML }}
+  {{ end }}
 </div>
 {{ partial "footer.html" . }}
 </nav>


### PR DESCRIPTION
I had the following errors when building a site with the latest Hugo version: 

```
ERROR deprecated: .Site.IsServer was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.133.0. Use hugo.IsServer instead.
ERROR deprecated: .Site.RSSLink was deprecated in Hugo v0.114.0 and will be removed in Hugo 0.133.0. Use the Output Format's Permalink method instead, e.g. .OutputFormats.Get "RSS".Permalink
```

# What is done in this PR

- Use `hugo.IsServer` instead of deprecated `.Site.IsServer`
- Use Output Format's Permalink method instead of deprecated `.Site.RSSLink` (See [Include reference feed](https://gohugo.io/templates/rss/#include-feed-reference))